### PR TITLE
assignBlueprint - changed converTo-Json depth to 5

### DIFF
--- a/assignBlueprint/assignBlueprint.ps1
+++ b/assignBlueprint/assignBlueprint.ps1
@@ -54,7 +54,7 @@ if ($BlueprintVersion -eq 'latest') {
 # Add Blueprint ID
 $body = Get-Content -Raw -Path $AssignmentFilePath | ConvertFrom-Json
 $body.properties.blueprintId = $BluePrintObject.id
-$body | ConvertTo-Json -Depth 4 | Out-File -FilePath $AssignmentFilePath -Encoding utf8 -Force
+$body | ConvertTo-Json -Depth 5 | Out-File -FilePath $AssignmentFilePath -Encoding utf8 -Force
 
 # Create Blueprint assignment
 try {


### PR DESCRIPTION
Unable to reference secret in Azure Key Vault from assign.json file.  During the conversion back to Json, the convertTo-Json was set to 4 which would result in a error.

> ##[error]Can't deserialize the JSON file 'D:\a\1\s\Blueprint\assign.json'. 'Error converting value "@{id=/subscriptions/Msub-id>/resourceGroups/providers/Microsoft.KeyVault/vaults/<keyvaultname}" to type 'Microsoft.Azure.Management.Blueprint.Models.KeyVaultReference'. Path 'reference.keyVault', line 68, position 245.'

Changing the depth to 5 resolved the error with Azure Key Vault.